### PR TITLE
Support for Scalar API beside of Swagger API and OpenAPI versioning

### DIFF
--- a/src/CleanArchitecture.Presentation/CleanArchitecture.Presentation.csproj
+++ b/src/CleanArchitecture.Presentation/CleanArchitecture.Presentation.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="Carter" Version="8.2.1" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.0.*" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/CleanArchitecture.Presentation/Program.cs
+++ b/src/CleanArchitecture.Presentation/Program.cs
@@ -3,8 +3,19 @@ using CleanArchitecture.Application.Services;
 using CleanArchitecture.Infrastructure;
 using CleanArchitecture.Infrastructure.Data.Extensions;
 using CleanArchitecture.Presentation;
+using Microsoft.OpenApi.Models;
+using Scalar.AspNetCore;
+using System;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
+var fullVersion = Assembly.GetExecutingAssembly()
+                          .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                          .InformationalVersion ?? "1.0.0";
+
+// Trim the commit hash suffix if it exists
+var version = fullVersion.Split('+')[0];
+
 
 // Add services to the container.
 builder.Services
@@ -12,13 +23,33 @@ builder.Services
   .AddInfrastructureServices(builder.Configuration)
   .AddApiServices(builder.Configuration);
 
-var app = builder.Build();
+builder.Services.AddSwaggerGen(opt =>
+            {
+              opt.SwaggerDoc("v1",
+              new OpenApiInfo
+              {
+                Title = "Cursus API - " + version,
+                Version = version
+              }
+               );
+            });
+   var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-  app.UseSwagger();
-  app.UseSwaggerUI();
+  app.UseSwagger(options =>
+  {
+    //https://localhost:5051/scalar/
+    options.RouteTemplate = "/openapi/{documentName}.json";
+  });
+  app.MapScalarApiReference();
+  app.UseSwaggerUI(c =>
+  //https://localhost:5051/swagger/
+  {
+    c.SwaggerEndpoint("/openapi/v1.json", "Cursus API");
+    //c.RoutePrefix = string.Empty;
+  });
   await app.InitializeDatabaseAsync();
 }
 

--- a/src/CleanArchitecture.Presentation/Properties/launchSettings.json
+++ b/src/CleanArchitecture.Presentation/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "applicationUrl": "http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -23,7 +23,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "applicationUrl": "https://localhost:5051;http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
Add Scalar API for testing while keeps Swagger API for backup. OpenAPI will now has versioning to keep track.