### PR TITLE
fix: don't set the default delivery date

### DIFF
--- a/src/CleanArchitecture.Application/Services/OrderService.cs
+++ b/src/CleanArchitecture.Application/Services/OrderService.cs
@@ -462,7 +462,7 @@ public class OrderService : IOrderService
         Quantity = ci.Quantity
       }).ToList(),
       // Set default delivery date to 7 days from now
-      DeliveryDate = _timeZoneService.ConvertToLocalTime(DateTime.UtcNow.AddDays(7))
+      //DeliveryDate = _timeZoneService.ConvertToLocalTime(DateTime.UtcNow.AddDays(7))
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the order creation process so that orders no longer display a pre-assigned delivery date by default, ensuring delivery dates appear only when explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->